### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -22,4 +22,4 @@ PackageUUID: d18defe2-ea8b-5af7-8ee9-e42adac5e2de
 RunJuliaNightlyOnCI: false
 UseCirrusCI: false
 _commit: v0.10.1
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
